### PR TITLE
#279 カレンダーの表示方法をVue.jsへ変更する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,8 +4,8 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "html",
             "dependencies": {
+                "@fullcalendar/vue3": "^5.11.2",
                 "vue3-carousel": "^0.1.47"
             },
             "devDependencies": {
@@ -1658,6 +1658,36 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@fullcalendar/common": {
+            "version": "5.11.3",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.3.tgz",
+            "integrity": "sha512-welVwyfQOXQQGfDwBMSfYEPbiO1cPfUD+C7jd3ZoweJR+dSO11ddFugxIQ7dGfABAGZ63oq/+LW9FsmAJezVNg==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@fullcalendar/core": {
+            "version": "5.11.3",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.3.tgz",
+            "integrity": "sha512-YUFxCvVJytUwFeXCx4J17kFMM7Ixwn9zBjVRw5NM2bMwgR6VAhSnlZc6yNQSOIy7Hj2TF0vDkO/4JNlTvxyAXw==",
+            "dependencies": {
+                "@fullcalendar/common": "~5.11.3",
+                "preact": "^10.0.5",
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@fullcalendar/vue3": {
+            "version": "5.11.2",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-5.11.2.tgz",
+            "integrity": "sha512-ELx9zaU5zqTTCqeDd2GNhkdiTGVwTjjFQAMCX2Cc3fGI5dtMwpQb9Sg9RtLhabmydakdClGffFwCIDa91IoGlg==",
+            "dependencies": {
+                "@fullcalendar/core": "~5.11.2",
+                "tslib": "^2.1.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.0.11"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -7451,6 +7481,15 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
+        "node_modules/preact": {
+            "version": "10.11.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.1.tgz",
+            "integrity": "sha512-1Wz5PCRm6Fg+6BTXWJHhX4wRK9MZbZBHuwBqfZlOdVm2NqPe8/rjYpufvYCwJSGb9layyzB2jTTXfpCTynLqFQ==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/preact"
+            }
+        },
         "node_modules/pretty-time": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
@@ -8832,8 +8871,7 @@
         "node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-            "dev": true
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
@@ -10923,6 +10961,33 @@
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
             "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
             "dev": true
+        },
+        "@fullcalendar/common": {
+            "version": "5.11.3",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.3.tgz",
+            "integrity": "sha512-welVwyfQOXQQGfDwBMSfYEPbiO1cPfUD+C7jd3ZoweJR+dSO11ddFugxIQ7dGfABAGZ63oq/+LW9FsmAJezVNg==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "@fullcalendar/core": {
+            "version": "5.11.3",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.3.tgz",
+            "integrity": "sha512-YUFxCvVJytUwFeXCx4J17kFMM7Ixwn9zBjVRw5NM2bMwgR6VAhSnlZc6yNQSOIy7Hj2TF0vDkO/4JNlTvxyAXw==",
+            "requires": {
+                "@fullcalendar/common": "~5.11.3",
+                "preact": "^10.0.5",
+                "tslib": "^2.1.0"
+            }
+        },
+        "@fullcalendar/vue3": {
+            "version": "5.11.2",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-5.11.2.tgz",
+            "integrity": "sha512-ELx9zaU5zqTTCqeDd2GNhkdiTGVwTjjFQAMCX2Cc3fGI5dtMwpQb9Sg9RtLhabmydakdClGffFwCIDa91IoGlg==",
+            "requires": {
+                "@fullcalendar/core": "~5.11.2",
+                "tslib": "^2.1.0"
+            }
         },
         "@jridgewell/gen-mapping": {
             "version": "0.3.2",
@@ -15396,6 +15461,11 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
+        "preact": {
+            "version": "10.11.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.1.tgz",
+            "integrity": "sha512-1Wz5PCRm6Fg+6BTXWJHhX4wRK9MZbZBHuwBqfZlOdVm2NqPe8/rjYpufvYCwJSGb9layyzB2jTTXfpCTynLqFQ=="
+        },
         "pretty-time": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
@@ -16456,8 +16526,7 @@
         "tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-            "dev": true
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "tty-browserify": {
             "version": "0.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
+                "@fullcalendar/core": "^5.11.3",
+                "@fullcalendar/daygrid": "^5.11.3",
                 "@fullcalendar/vue3": "^5.11.2",
                 "vue3-carousel": "^0.1.47"
             },
@@ -1675,6 +1677,15 @@
             "dependencies": {
                 "@fullcalendar/common": "~5.11.3",
                 "preact": "^10.0.5",
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@fullcalendar/daygrid": {
+            "version": "5.11.3",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
+            "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
+            "dependencies": {
+                "@fullcalendar/common": "~5.11.3",
                 "tslib": "^2.1.0"
             }
         },
@@ -10977,6 +10988,15 @@
             "requires": {
                 "@fullcalendar/common": "~5.11.3",
                 "preact": "^10.0.5",
+                "tslib": "^2.1.0"
+            }
+        },
+        "@fullcalendar/daygrid": {
+            "version": "5.11.3",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
+            "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
+            "requires": {
+                "@fullcalendar/common": "~5.11.3",
                 "tslib": "^2.1.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "vue-loader": "^16.8.3"
     },
     "dependencies": {
+        "@fullcalendar/vue3": "^5.11.2",
         "vue3-carousel": "^0.1.47"
     }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
         "vue-loader": "^16.8.3"
     },
     "dependencies": {
+        "@fullcalendar/core": "^5.11.3",
+        "@fullcalendar/daygrid": "^5.11.3",
         "@fullcalendar/vue3": "^5.11.2",
         "vue3-carousel": "^0.1.47"
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,10 +6,11 @@
 
 require('./bootstrap');
 
-// import { createApp } from 'vue/dist/vue.esm-bundler.js';
 import { createApp } from 'vue'
 import AsyncComment from './components/AsyncComment.vue'
 import HowToSection from './components/HowToSection.vue'
+// FullCalendarテストのために読み込み
+import './calendar';
 
 createApp({
     components:{

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -1,0 +1,15 @@
+import { Calendar } from "@fullcalendar/core";
+import dayGridPlugin from "@fullcalendar/daygrid";
+
+var calendarEl = document.getElementById("calendar");
+
+let calendar = new Calendar(calendarEl, {
+    plugins: [dayGridPlugin],
+    initialView: "dayGridMonth",
+    headerToolbar: {
+        left: "prev,next today",
+        center: "title",
+        right: "",
+    },
+});
+calendar.render();

--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <div id='calendar'></div>
+    <script src="{{ mix('js/app.js') }}"></script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,11 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+// Full-Calendarテスト
+Route::get('/calendar', function(){
+    return view('calendar');
+});
+
 // ユーザー登録
 Route::controller(Auth\RegisterController::class)->prefix('signup')->group(function() {
     Route::get('/', 'showRegistrationForm')->name('signup.get');

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,7 +14,7 @@ const mix = require('laravel-mix');
 mix.js('resources/js/app.js', 'public/js')
     .vue()
     .sass('resources/sass/app.scss', 'public/css')
-    .js('resources/js/comment.js', 'public/js')
+    .js('resources/js/calendar.js', 'public/js')
     .sourceMaps()
     .autoload({
         "jquery": ['$', 'window.jQuery'],


### PR DESCRIPTION
close #279 
V-Calendarでの対応がアルファ版になるため、FullCalendarでの対応に変更。
別IssueでDBからの表示、登録対応を行うようにする。