### PR TITLE
#445 コメント文字数制限追加

### DIFF
--- a/app/Adapters/Comment/SaveCommentAdapter.php
+++ b/app/Adapters/Comment/SaveCommentAdapter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Adapters\Comment;
+
+use App\Comment as EloquentComment;
+use Core\src\Comment\Domain\Models\Comment;
+use Core\src\Comment\UseCase\Ports\SaveCommentCommandPort;
+
+class SaveCommentAdapter implements SaveCommentCommandPort
+{
+    /**
+     * @var EloquentComment
+     */
+    private $eloquentComment;
+
+    public function __construct(EloquentComment $eloquentComment)
+    {
+        $this->eloquentComment = $eloquentComment;
+    }
+
+    public function saveComment(Comment $comment): void
+    {
+        $commentParam = [
+            'bikeId' => $comment->bikeId()->toInt(),
+            'receiverId' => $comment->receiverId()->toInt(),
+            'senderId' => $comment->senderId()->toInt(),
+            'body' => $comment->commentBody()->toString(),
+            'sendDateTime' => $comment->sendDateTime()
+        ];
+        $this->eloquentComment->saveComment($commentParam);
+    }
+}

--- a/app/Comment.php
+++ b/app/Comment.php
@@ -20,7 +20,7 @@ class Comment extends Model
     protected $table = 'comments';
 
     protected $fillable = [
-        'body', 'sender_id', 'receiver_id', 'bike_id',
+        'body', 'sender_id', 'receiver_id', 'bike_id', 'created_at'
     ];
 
     /** 一対多の記述(コメントは一人のユーザに従属) */

--- a/app/Comment.php
+++ b/app/Comment.php
@@ -96,27 +96,16 @@ class Comment extends Model
         return [$bike, $login_user, $sender, $sender_comments, $receiver, $receiver_comments];
     }
 
-    /**
-     * DBにコメントを保存する
-     *
-     * @param object $request コメント本文を含むオブジェクト
-     * @param int $bikeId 対象自転車のid
-     * @param int $senderId コメント送信者id
-     * @param int $receiverId コメント受信者id
-     * @return void
-     */
-    public function saveComment($request, $bikeId, $senderId, $receiverId)
+    public function saveComment(array $param): void
     {
-        /* コメント本文 */
-        $this->body = $request->body;
-        /* コメント送信者ID */
-        $this->sender_id = $senderId;
-        /* レンタル対象自転車ID */
-        $this->bike_id = $bikeId;
-        /* コメント受信者ID */
-        $this->receiver_id = $receiverId;
-        /* DBにコメント情報を保存する */
-        $this->save();
+        $query = $this->newQuery();
+        $query->create([
+            'bike_id' => $param['bikeId'],
+            'sender_id' => $param['senderId'],
+            'receiver_id' => $param['receiverId'],
+            'body' => $param['body'],
+            'created_at' => $param['sendDateTime']
+        ]);
     }
 
     public function toModel(array $values): ModelsComment

--- a/app/Consts/Word.php
+++ b/app/Consts/Word.php
@@ -15,7 +15,7 @@ class Word
         'bikes_index' => '貸出中の自転車はこちらから',
         'search' => '貸出中の自転車を検索する',
         'not_comma' => '価格はコンマなしで入力してください。',
-        'within_150words' => '150文字以内で入力してください。',
+        'within_140words' => '140文字以内で入力してください。',
         'required_content' => 'は必須項目です。',
         'copyright_icon' => '©',
         'copyright' => 'Copyright: Daichi Sugiyama',

--- a/app/Http/Controllers/Message/SendMessageController.php
+++ b/app/Http/Controllers/Message/SendMessageController.php
@@ -3,18 +3,17 @@
 namespace App\Http\Controllers\Message;
 
 use App\Events\MessageAdded;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Comment\SendRequest;
 use Illuminate\Support\Facades\DB;
 
 class SendMessageController extends Controller
 {
     private $message;
 
-    // TODO 要Requestクラスでのバリデーション #445
-    public function __invoke(Request $request, int $loginUserId, int $anotherUserId, int $bikeId)
+    public function __invoke(SendRequest $request, int $loginUserId, int $anotherUserId, int $bikeId)
     {
-        $this->message = $request->input('message');
+        $this->message = $request->message();
         $param = [
             'bike_id' => $bikeId,
             'receiver_id' => $anotherUserId,

--- a/app/Http/Controllers/Message/SendMessageController.php
+++ b/app/Http/Controllers/Message/SendMessageController.php
@@ -11,6 +11,7 @@ class SendMessageController extends Controller
 {
     private $message;
 
+    // TODO 要Requestクラスでのバリデーション #445
     public function __invoke(Request $request, int $loginUserId, int $anotherUserId, int $bikeId)
     {
         $this->message = $request->input('message');

--- a/app/Http/Requests/Comment/SendRequest.php
+++ b/app/Http/Requests/Comment/SendRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Comment;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\Comment;
+use Illuminate\Contracts\Validation\Validator;
+
+class SendRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'message' => [new Comment]
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function message()
+    {
+        return $this->input('message');
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        parent::failedValidation($validator);
+    }
+}

--- a/app/Http/Requests/Comment/SendRequest.php
+++ b/app/Http/Requests/Comment/SendRequest.php
@@ -20,10 +20,7 @@ class SendRequest extends FormRequest
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function message()
+    public function message(): string
     {
         return $this->input('message');
     }

--- a/app/Providers/CommentServiceProvider.php
+++ b/app/Providers/CommentServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Adapters\Comment\GetCommentAdapter;
+use App\Adapters\Comment\SaveCommentAdapter;
 use Core\src\Comment\UseCase\Ports\GetCommentQueryPort;
+use Core\src\Comment\UseCase\Ports\SaveCommentCommandPort;
 use Illuminate\Support\ServiceProvider;
 
 class CommentServiceProvider extends ServiceProvider
@@ -16,6 +18,7 @@ class CommentServiceProvider extends ServiceProvider
     public function register()
     {
         app()->bind(GetCommentQueryPort::class, GetCommentAdapter::class);
+        app()->bind(SaveCommentCommandPort::class, SaveCommentAdapter::class);
     }
 
     /**

--- a/app/Rules/Comment.php
+++ b/app/Rules/Comment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class Comment implements ValidationRule
+{
+    const MAX_COMMENT_LENGTH = 5;
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (mb_strlen($value) > self::MAX_COMMENT_LENGTH) {
+            $fail('入力できる最大文字数は140文字です。');
+        }
+    }
+}

--- a/app/Rules/Comment.php
+++ b/app/Rules/Comment.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class Comment implements ValidationRule
 {
-    const MAX_COMMENT_LENGTH = 5;
+    const MAX_COMMENT_LENGTH = 140;
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/core/src/Comment/Domain/Models/Comment.php
+++ b/core/src/Comment/Domain/Models/Comment.php
@@ -2,6 +2,7 @@
 
 namespace Core\src\Comment\Domain\Models;
 
+use Carbon\Carbon;
 use Core\src\Bike\Domain\Models\BikeId;
 
 final class Comment
@@ -23,12 +24,18 @@ final class Comment
      */
     private $commentBody;
 
-    public function __construct($senderId, $receiverId, $bikeId, $commentBody)
+    /**
+     * @var Carbon
+     */
+    private $sendDateTime;
+
+    public function __construct($senderId, $receiverId, $bikeId, $commentBody, $sendDateTime)
     {
         $this->senderId = $senderId;
         $this->receiverId = $receiverId;
         $this->bikeId = $bikeId;
         $this->commentBody = $commentBody;
+        $this->sendDateTime  = $sendDateTime;
     }
 
     public function senderId(): SenderId
@@ -51,13 +58,18 @@ final class Comment
         return $this->commentBody;
     }
 
+    public function sendDateTime(): Carbon
+    {
+        return $this->sendDateTime;
+    }
     public static function fromArray(array $value): self
     {
         return new self(
             SenderId::of($value['sender_id'] ?? 0),
             ReceiverId::of($value['receiver_id'] ?? 0),
             BikeId::of($value['bike_id'] ?? 0),
-            CommentBody::of($value['body'] ?? '')
+            CommentBody::of($value['body'] ?? ''),
+            Carbon::now()
         );
     }
 }

--- a/core/src/Comment/Domain/Models/Comment.php
+++ b/core/src/Comment/Domain/Models/Comment.php
@@ -7,26 +7,15 @@ use Core\src\Bike\Domain\Models\BikeId;
 
 final class Comment
 {
-    /**
-     * @var SenderId
-     */
+    /** @var SenderId */
     private $senderId;
-    /**
-     * @var ReceiverId
-     */
+    /** @var ReceiverId */
     private $receiverId;
-    /**
-     * @var BikeId
-     */
+    /** @var BikeId */
     private $bikeId;
-    /**
-     * @var CommentBody
-     */
+    /** @var CommentBody */
     private $commentBody;
-
-    /**
-     * @var Carbon
-     */
+    /** @var Carbon */
     private $sendDateTime;
 
     public function __construct($senderId, $receiverId, $bikeId, $commentBody, $sendDateTime)
@@ -69,7 +58,7 @@ final class Comment
             ReceiverId::of($value['receiver_id'] ?? 0),
             BikeId::of($value['bike_id'] ?? 0),
             CommentBody::of($value['body'] ?? ''),
-            Carbon::now()
+            $value['sendDateTime'] ?? Carbon::now()
         );
     }
 }

--- a/core/src/Comment/Domain/Models/CommentBody.php
+++ b/core/src/Comment/Domain/Models/CommentBody.php
@@ -7,4 +7,29 @@ use App\ValueObjects\ValueObjectString;
 final class CommentBody
 {
     use ValueObjectString;
+
+    const MIN_COMMENT_LENGTH = 1;
+    const MAX_COMMENT_LENGTH = 140;
+
+    /** @param string $value */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        if (!self::validate($value)) {
+            throw new \InvalidArgumentException('文字の入力数が不正です。');
+        }
+        $this->value = $value;
+    }
+
+    private function validate(string $value): bool
+    {
+        if (mb_strlen($value) > self::MAX_COMMENT_LENGTH) {
+            return false;
+        }
+        if (mb_strlen($value) < self::MIN_COMMENT_LENGTH) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/core/src/Comment/UseCase/Ports/SaveCommentCommandPort.php
+++ b/core/src/Comment/UseCase/Ports/SaveCommentCommandPort.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Core\src\Comment\UseCase\Ports;
+
+use Core\src\Comment\Domain\Models\Comment;
+
+interface SaveCommentCommandPort
+{
+    public function saveComment(Comment $comment): void;
+}

--- a/core/src/Comment/UseCase/SendComment.php
+++ b/core/src/Comment/UseCase/SendComment.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Core\src\Comment\UseCase;
+
+use App\Events\MessageAdded;
+use Core\src\Comment\Domain\Models\Comment;
+use Core\src\Comment\UseCase\Ports\SaveCommentCommandPort;
+
+final class SendComment
+{
+    /**
+     * @var SaveCommentCommandPort
+     */
+    private $saveCommentCommandPort;
+
+    public function __construct(SaveCommentCommandPort $saveCommentCommandPort)
+    {
+        $this->saveCommentCommandPort = $saveCommentCommandPort;
+    }
+
+    public function execute(array $commentValues)
+    {
+        $this->saveCommentCommandPort->saveComment(Comment::fromArray($commentValues));
+        event((new MessageAdded($commentValues))->dontBroadcastToCurrentUser());
+    }
+}

--- a/core/src/User/UseCase/Ports/GetUserQueryPort.php
+++ b/core/src/User/UseCase/Ports/GetUserQueryPort.php
@@ -5,7 +5,7 @@ namespace Core\src\User\UseCase\Ports;
 use Core\src\User\Domain\Models\User;
 use Core\src\User\Domain\Models\UserId;
 
-interface getUserQueryPort
+interface GetUserQueryPort
 {
     public function findByUserId(UserId $userId): User;
 }

--- a/database/migrations/2023_10_14_095639_change_body_column_type_to_varchar_on_comments_table.php
+++ b/database/migrations/2023_10_14_095639_change_body_column_type_to_varchar_on_comments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->string('body', 140)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->text('body')->change();
+        });
+    }
+};

--- a/resources/ts/sendMessage.ts
+++ b/resources/ts/sendMessage.ts
@@ -29,7 +29,8 @@ const sendMessage = (): void => {
 			btnSendMessage.setAttribute("disabled", "");
 		})
 		.catch((error) => {
-			console.log(error);
+			const errorMessage: string = error.response.data.message;
+			alert(errorMessage);
 		});
 };
 

--- a/resources/views/auth/bikeregister.blade.php
+++ b/resources/views/auth/bikeregister.blade.php
@@ -61,7 +61,7 @@
                 <div class="mt-3">
                     <label for="remark">{{ $bike_form_label['remark'] }}</label>
                     <textarea class="form-control" name="remark" cols="50" rows="2"
-                        placeholder="{{ Word::WORD_LIST['within_150words'] }}" maxlength="150"
+                        placeholder="{{ Word::WORD_LIST['within_140words'] }}" maxlength="140"
                         enterkeyhint=”next”>{{ old('remark') }}</textarea>
                 </div>
 

--- a/resources/views/components/comments/form.blade.php
+++ b/resources/views/components/comments/form.blade.php
@@ -8,8 +8,8 @@
 @else
 <div class="col-md-6">
     <h2>コメント</h2>
-    <input id="input-message" type="text" class="form-control" placeholder="{{ Word::WORD_LIST['within_140words'] }}"
-        maxlength="140" enterkeyhint=”next”>
+    <input id="input-message" name="message" type="text" class="form-control"
+        placeholder="{{ Word::WORD_LIST['within_140words'] }}" maxlength="140" enterkeyhint=”next”>
     <button id="btn-message-send" class="btn btn-primary mt-2" disabled enterkeyhint=”send”>送信</button>
     <ul id="list-block">
     </ul>

--- a/resources/views/components/comments/form.blade.php
+++ b/resources/views/components/comments/form.blade.php
@@ -8,8 +8,9 @@
 @else
 <div class="col-md-6">
     <h2>コメント</h2>
-    <input id="input-message" type="text" class="form-control">
-    <button id="btn-message-send" class="btn btn-primary mt-2" disabled>送信</button>
+    <input id="input-message" type="text" class="form-control" placeholder="{{ Word::WORD_LIST['within_140words'] }}"
+        maxlength="140" enterkeyhint=”next”>
+    <button id="btn-message-send" class="btn btn-primary mt-2" disabled enterkeyhint=”send”>送信</button>
     <ul id="list-block">
     </ul>
 </div>

--- a/tests/Unit/Adapter/Comment/SaveCommentAdapterTest.php
+++ b/tests/Unit/Adapter/Comment/SaveCommentAdapterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace tests\Unit\Adapter\Comment;
+
+use App\Adapters\Comment\SaveCommentAdapter;
+use App\Bike;
+use App\Comment as EloquentComment;
+use App\User;
+use Carbon\Carbon;
+use Core\src\Comment\Domain\Models\Comment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class SaveCommentAdapterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var SaveCommentAdapter
+     */
+    private $saveCommentAdapter;
+    /** 
+     * @var Comment
+     */
+    private $comment;
+
+    private $commentValue;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->saveCommentAdapter = new SaveCommentAdapter(new EloquentComment());
+
+        // 送信・受信で各1名ずつが必要なのでループ処理
+        for ($i = 0; $i < 2; $i++) {
+            User::factory()->create([
+                'id' => 3 + $i
+            ]);
+        }
+        Bike::factory()->create([
+            'id' => 2,
+            'user_id' => 3,
+        ]);
+
+        $this->commentValue = [
+            'sender_id' => 4,
+            'receiver_id' => 3,
+            'bike_id' => 2,
+            'body' => 'テストコメント1',
+            'sendDateTime' => Carbon::parse('2023-10-28 12:00:00')
+        ];
+        $this->comment = Comment::fromArray($this->commentValue);
+    }
+
+    public function testSaveComment()
+    {
+        $this->saveCommentAdapter->saveComment($this->comment);
+        $this->assertDatabaseHas('comments', [
+            'sender_id' => 4,
+            'receiver_id' => 3,
+            'bike_id' => 2,
+            'body' => 'テストコメント1',
+            'created_at' => Carbon::parse('2023-10-28 12:00:00')
+        ]);
+    }
+}

--- a/tests/Unit/Model/Comment/CommentBodyTest.php
+++ b/tests/Unit/Model/Comment/CommentBodyTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Model\Comment;
+
+use Core\src\Comment\Domain\Models\CommentBody;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class CommentBodyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    const OK_MESSAGE_VALUE = 'コメント生成用';
+
+    public function testCommentBody()
+    {
+        $commentBody = CommentBody::of(self::OK_MESSAGE_VALUE);
+        $this->assertSame(self::OK_MESSAGE_VALUE, $commentBody->toString());
+    }
+
+    /**
+     * @dataProvider validateDataProvider
+     */
+    public function testValidate(string $value, $expectedInstance, ?string $exceptionMessage): void
+    {
+        try {
+            $commentBody = new CommentBody($value);
+            $this->assertInstanceOf($expectedInstance, $commentBody);
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertInstanceOf($expectedInstance, $exception);
+            $this->assertSame($exceptionMessage, $exception->getMessage());
+        }
+    }
+
+    public function validateDataProvider()
+    {
+        return [
+            '文字数140' => [
+                'value' => 'あいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえお
+                あいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあ
+                あいうえおあいうえおあいうえおあいうえお',
+                'expectedInstance' => CommentBody::class,
+                'exceptionMessage' => null
+            ],
+            '文字数0' => [
+                'value' => '',
+                'expectedInstance' => InvalidArgumentException::class,
+                'exceptionMessage' => '文字の入力数が不正です。'
+            ],
+            '文字数141以上' => [
+                'value' => 'あいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえお
+                あいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえおあいうえお
+                あいうえおあいうえおあいうえおあいうえお141文字以上',
+                'expectedInstance' => InvalidArgumentException::class,
+                'exceptionMessage' => '文字の入力数が不正です。'
+            ]
+        ];
+    }
+}

--- a/tests/Unit/UseCase/Comment/SendCommentTest.php
+++ b/tests/Unit/UseCase/Comment/SendCommentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace core\tests\UseCase\Comment;
+
+use Carbon\Carbon;
+use Core\src\Comment\Domain\Models\Comment;
+use Core\src\Comment\UseCase\Ports\SaveCommentCommandPort;
+use Core\src\Comment\UseCase\SendComment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class SendCommentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $useCase;
+
+    public function testExcute()
+    {
+        $this->useCase = new SendComment(
+            new class implements SaveCommentCommandPort
+            {
+                public function saveComment(Comment $comment): void
+                {
+                }
+            }
+        );
+
+        $arrayValue = [
+            'sender_id' => 4,
+            'receiver_id' => 3,
+            'bike_id' => 2,
+            'body' => 'テストコメント1',
+            'sendDateTime' => Carbon::parse('2023-10-28 12:00:00')
+        ];
+
+        $response = $this->useCase->execute($arrayValue);
+        $this->assertNull($response);
+    }
+}


### PR DESCRIPTION
## 実装背景
- コメント文字数制限することで、悪意のあるユーザーからのDos攻撃を防止するため

## 備考
- 一部コードにコアレイヤパターンを適用
- Controllerのテストは未実装